### PR TITLE
Simplify regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ module.exports = function(url) {
   var host = window.location.hostname;
 
   var linkHost = function(url) {
-    if (/^(http|https):\/\//.test(url)) { // Absolute URL.
+    if (/^https?:\/\//.test(url)) { // Absolute URL.
       // The easy way to parse an URL, is to create <a> element.
       // @see: https://gist.github.com/jlong/2428561
       var parser = document.createElement('a');


### PR DESCRIPTION
This removes the unnecessary capture group and makes the `s` in https optional